### PR TITLE
Update MRA rotation to match core

### DIFF
--- a/releases/Ikari Warriors.mra
+++ b/releases/Ikari Warriors.mra
@@ -9,7 +9,7 @@
 	<rbf>IkariWarriors</rbf>
 	<about author="RndMnkIII" twitter="@RndMnkIII"></about>
 	<resolution>16.1785kHz</resolution>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<players>2</players>
 	<joystick>8-way</joystick>
 	<special_controls></special_controls>

--- a/releases/Victory Road.mra
+++ b/releases/Victory Road.mra
@@ -9,7 +9,7 @@
 	<rbf>IkariWarriors</rbf>
 	<about author="RndMnkIII" twitter="@RndMnkIII"></about>
 	<resolution>16.1785kHz</resolution>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<players>2</players>
 	<joystick>8-way</joystick>
 	<special_controls>Rotary</special_controls>


### PR DESCRIPTION
Core outputs video that is CW rotated. Because the direct video info frame pulls rotation direction from the MRA, it should match the core's output.